### PR TITLE
C++17 fixes

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -121,10 +121,13 @@ enum {
 extern const char * opnames[EQU_BASE];
 #define XNOR 6  //XNOR and EQU are the same function
 
-#define BOOL_FALSE 0
-#define BOOL_TRUE 1
-#define BOOL_UNKNOWN 2
-#define BOOL_MAX 3
+/* fixing a wall of compiler warnings from redefining BOOL_MAX */
+enum SBSAT_BOOL {
+   BOOL_FALSE = 0,
+   BOOL_TRUE = 1,
+   BOOL_UNKNOWN = 2,
+   BOOL_ENUM_MAX = 3
+};
 
 /* various stacks */
 #define LEVEL_START -1

--- a/src/formats/5/x/libt5_la-iscas_g.cc
+++ b/src/formats/5/x/libt5_la-iscas_g.cc
@@ -212,7 +212,7 @@ union yyalloc
 #   define YYCOPY(To, From, Count)		\
       do					\
 	{					\
-	  register YYSIZE_T yyi;		\
+	  YYSIZE_T yyi;		\
 	  for (yyi = 0; yyi < (Count); yyi++)	\
 	    (To)[yyi] = (From)[yyi];	\
 	}					\
@@ -551,7 +551,7 @@ yystrlen (yystr)
      const char *yystr;
 #   endif
 {
-  register const char *yys = yystr;
+  const char *yys = yystr;
 
   while (*yys++ != '\0')
     continue;
@@ -576,8 +576,8 @@ yystpcpy (yydest, yysrc)
      const char *yysrc;
 #   endif
 {
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
   while ((*yyd++ = *yys++) != '\0')
     continue;
@@ -698,8 +698,8 @@ yyparse (YYPARSE_PARAM_ARG)
      YYPARSE_PARAM_DECL
 {
   
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   int yyresult;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
@@ -717,12 +717,12 @@ yyparse (YYPARSE_PARAM_ARG)
   /* The state stack.  */
   short	yyssa[YYINITDEPTH];
   short *yyss = yyssa;
-  register short *yyssp;
+  short *yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE yyvsa[YYINITDEPTH];
   YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
+  YYSTYPE *yyvsp;
 
 
 

--- a/src/formats/5/x/libt5_la-prover3_g.cc
+++ b/src/formats/5/x/libt5_la-prover3_g.cc
@@ -196,7 +196,7 @@ union yyalloc
 #   define YYCOPY(To, From, Count)		\
       do					\
 	{					\
-	  register YYSIZE_T yyi;		\
+	  YYSIZE_T yyi;		\
 	  for (yyi = 0; yyi < (Count); yyi++)	\
 	    (To)[yyi] = (From)[yyi];	\
 	}					\
@@ -531,7 +531,7 @@ yystrlen (yystr)
      const char *yystr;
 #   endif
 {
-  register const char *yys = yystr;
+  const char *yys = yystr;
 
   while (*yys++ != '\0')
     continue;
@@ -556,8 +556,8 @@ yystpcpy (yydest, yysrc)
      const char *yysrc;
 #   endif
 {
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
   while ((*yyd++ = *yys++) != '\0')
     continue;
@@ -678,8 +678,8 @@ yyparse (YYPARSE_PARAM_ARG)
      YYPARSE_PARAM_DECL
 {
   
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   int yyresult;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
@@ -697,12 +697,12 @@ yyparse (YYPARSE_PARAM_ARG)
   /* The state stack.  */
   short	yyssa[YYINITDEPTH];
   short *yyss = yyssa;
-  register short *yyssp;
+  short *yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE yyvsa[YYINITDEPTH];
   YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
+  YYSTYPE *yyvsp;
 
 
 

--- a/src/formats/5/x/libt5_la-prover_g.cc
+++ b/src/formats/5/x/libt5_la-prover_g.cc
@@ -207,7 +207,7 @@ union yyalloc
 #   define YYCOPY(To, From, Count)		\
       do					\
 	{					\
-	  register YYSIZE_T yyi;		\
+	  YYSIZE_T yyi;		\
 	  for (yyi = 0; yyi < (Count); yyi++)	\
 	    (To)[yyi] = (From)[yyi];	\
 	}					\
@@ -545,7 +545,7 @@ yystrlen (yystr)
      const char *yystr;
 #   endif
 {
-  register const char *yys = yystr;
+  const char *yys = yystr;
 
   while (*yys++ != '\0')
     continue;
@@ -570,8 +570,8 @@ yystpcpy (yydest, yysrc)
      const char *yysrc;
 #   endif
 {
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
   while ((*yyd++ = *yys++) != '\0')
     continue;
@@ -692,8 +692,8 @@ yyparse (YYPARSE_PARAM_ARG)
      YYPARSE_PARAM_DECL
 {
   
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   int yyresult;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
@@ -711,12 +711,12 @@ yyparse (YYPARSE_PARAM_ARG)
   /* The state stack.  */
   short	yyssa[YYINITDEPTH];
   short *yyss = yyssa;
-  register short *yyssp;
+  short *yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE yyvsa[YYINITDEPTH];
   YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
+  YYSTYPE *yyvsp;
 
 
 

--- a/src/preproc/do_prover3.cc
+++ b/src/preproc/do_prover3.cc
@@ -38,11 +38,11 @@
 #include "sbsat.h"
 #include "sbsat_preproc.h"
 
-int size = 10;
+int do_prover3_size = 10;
 
 int Do_Prover3() {
 	if(formatin != '3') return PREP_NO_CHANGE;
-	dX_printf(3, "RECOMPUTING PROVER %d - \n", size);
+	dX_printf(3, "RECOMPUTING PROVER %d - \n", do_prover3_size);
 	str_length = 0;
 	bool OLD_DO_INFERENCES = DO_INFERENCES;
 	DO_INFERENCES = 0;
@@ -85,7 +85,7 @@ int Do_Prover3() {
 
 	//Grabbing new prover3 BDDS
    nmbrFunctions = 0;
-	prover3_max_vars = size;
+	prover3_max_vars = do_prover3_size;
 	void p3_done();
    p3_done();
 	

--- a/src/solv_smurf/fn_minmax/bt_specfn_minmax.cc
+++ b/src/solv_smurf/fn_minmax/bt_specfn_minmax.cc
@@ -46,7 +46,7 @@ InferNLits_MINMAX(int nFnId, int nNumRHSUnknowns, int value)
 {
    int nNumElts = arrSolverFunctions[nFnId].fn_minmax.rhsVbles.nNumElts;
    int *arrElts = arrSolverFunctions[nFnId].fn_minmax.rhsVbles.arrElts;
-   int arrNewPolar[BOOL_MAX];
+   int arrNewPolar[BOOL_ENUM_MAX];
    if (value == BOOL_TRUE) {
       arrNewPolar[BOOL_TRUE] = BOOL_TRUE;
       arrNewPolar[BOOL_FALSE] = BOOL_FALSE;

--- a/src/solver/bt_specfn_minmax.cc
+++ b/src/solver/bt_specfn_minmax.cc
@@ -45,7 +45,7 @@ InferNLits_MINMAX(SpecialFunc *pSpecialFunc, int nNumRHSUnknowns, int value)
 {
    int nNumElts = pSpecialFunc->rhsVbles.nNumElts;
    int *arrElts = pSpecialFunc->rhsVbles.arrElts;
-   int arrNewPolar[BOOL_MAX];
+   int arrNewPolar[BOOL_ENUM_MAX];
    if (value == BOOL_TRUE) {
       arrNewPolar[BOOL_TRUE] = BOOL_TRUE;
       arrNewPolar[BOOL_FALSE] = BOOL_FALSE;


### PR DESCRIPTION
This pull request fixes an issue where SBSAT does not compile for C++17 or later because ``sbsat_headers.h`` uses ``using namespace std;``, and ``do_prover3.cc`` declares a global variable ``int size`` which is implicitly ``std::size``, and ``std::size`` is already defined in the standard library for C++17.

Also, I added a fix for compiler warnings for BOOL_MAX and removed the ``register`` keyword from all ``*.cc`` files as it does nothing in C++17.